### PR TITLE
Return remaining cached value on unaligned error

### DIFF
--- a/bitio_test.go
+++ b/bitio_test.go
@@ -94,6 +94,18 @@ func TestReaderEOF(t *testing.T) {
 	eq(0, n)
 	eq(io.EOF, err)
 }
+func TestReaderUnalignedEOF(t *testing.T) {
+	eq := mighty.Eq(t)
+
+	r := NewReader(bytes.NewBuffer([]byte{0xFF}))
+
+	b, err := r.ReadBits(4)
+	eq(byte(15), byte(b))
+	eq(nil, err)
+	b, err = r.ReadBits(5)
+	eq(byte(15), byte(b))
+	eq(io.EOF, err)
+}
 
 func TestReaderEOF2(t *testing.T) {
 	eq, expEq := mighty.EqExpEq(t)

--- a/reader.go
+++ b/reader.go
@@ -100,7 +100,7 @@ func (r *reader) ReadBits(n byte) (u uint64, err error) {
 		// Read last fraction, if any
 		if n > 0 {
 			if r.cache, err = r.in.ReadByte(); err != nil {
-				return 0, err
+				return u, err
 			}
 			shift := 8 - n
 			u = u<<n + uint64(r.cache>>shift)


### PR DESCRIPTION
Return remaining cached value on unaligned error